### PR TITLE
Broken link fixes

### DIFF
--- a/demos-ssi/theme-gcwu-fegc/serv-eng-fra.shtm
+++ b/demos-ssi/theme-gcwu-fegc/serv-eng-fra.shtm
@@ -31,14 +31,14 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <div class="span-4"><section><h2>Message title (h2)</h2>
 <p>Message message message message message message message message message message message message message message message message message message message message.</p>
 <ul>
-<li><a href="../../docs/index-eng.html">Home</a></li>
+<li><a href="#">Home</a></li>
 <li><a href="#">Contact us</a></li>
 </ul>
 </section></div>
 <div class="span-4" lang="fr"><section><h2>Titre du message (h2)</h2>
 <p>Message message message message message message message message message message message message message message message message message message message message.</p>
 <ul>
-<li><a href="../../docs/index-fra.html">Accueil</a></li>
+<li><a href="#">Accueil</a></li>
 <li><a href="#">Contactez-nous</a></li>
 </ul>
 </section></div>

--- a/demos-ssi/theme-gcwu-fegc/serv-fra-eng.shtm
+++ b/demos-ssi/theme-gcwu-fegc/serv-fra-eng.shtm
@@ -31,14 +31,14 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <div class="span-4"><section><h2>Titre du message (h2)</h2>
 <p>Message message message message message message message message message message message message message message message message message message message message.</p>
 <ul>
-<li><a href="../../docs/index-fra.html">Accueil</a></li>
+<li><a href="#">Accueil</a></li>
 <li><a href="#">Contactez-nous</a></li>
 </ul>
 </section></div>
 <div class="span-4" lang="en"><section><h2>Message title (h2)</h2>
 <p>Message message message message message message message message message message message message message message message message message message message message.</p>
 <ul>
-<li><a href="../../docs/index-eng.html">Home</a></li>
+<li><a href="#">Home</a></li>
 <li><a href="#">Contact us</a></li>
 </ul>
 </section></div>


### PR DESCRIPTION
Fixed a couple of leftover references to _docs/index-lang.html_ (which don't exist in the SSI variant) to point to "#".
