### PR TITLE
Double slash fix in search file variable declaration

### DIFF
--- a/demos/ssi/inc/config.shtm
+++ b/demos/ssi/inc/config.shtm
@@ -45,7 +45,7 @@
 <!--#set var="gc-search-fra" value="Recherche"-->
 <!--#set var="gc-search-label-eng" value="Search website"-->
 <!--#set var="gc-search-label-fra" value="Recherchez le site web"-->
-<!--#set var="gc-search-file" value="/${gc-theme-folder}/inc/cont/search.shtm"-->
+<!--#set var="gc-search-file" value="${gc-theme-folder}/inc/cont/search.shtm"-->
 <!--#set var="gc-sitenav-eng" value="<span>Site </span>menu"-->
 <!--#set var="gc-sitenav-fra" value="Menu<span> du site</span>"-->
 <!--#set var="gc-menuprim-eng" value="/demos/includes/menu-eng.inc"-->


### PR DESCRIPTION
Should be noted that even though the removed slash in the attached commit caused a double slashing effect, the search box would still get loaded in properly anyways.

Removing the slash should make life easier for anyone who tries to run mass find/replaces on file paths in their copies of the SSI variant's files :).
