### PR TITLE
Updated ajax-replace references to mega menu demo includes.

### DIFF
--- a/demos/ssi/inc/config.shtm
+++ b/demos/ssi/inc/config.shtm
@@ -48,8 +48,8 @@
 <!--#set var="gc-search-file" value="${gc-theme-folder}/inc/cont/search.shtm"-->
 <!--#set var="gc-sitenav-eng" value="<span>Site </span>menu"-->
 <!--#set var="gc-sitenav-fra" value="Menu<span> du site</span>"-->
-<!--#set var="gc-menuprim-eng" value="/demos/includes/menu-eng.inc"-->
-<!--#set var="gc-menuprim-fra" value="/demos/includes/menu-fra.inc"-->
+<!--#set var="gc-menuprim-eng" value="/demos/includes/menu-eng.txt"-->
+<!--#set var="gc-menuprim-fra" value="/demos/includes/menu-fra.txt"-->
 <!--#set var="gc-bcrumb-eng" value="Breadcrumb trail"-->
 <!--#set var="gc-bcrumb-fra" value="Fil d'Ariane"-->
 <!--#set var="gc-doc-dates-eng" value="Date modified:"-->


### PR DESCRIPTION
Since the file extensions of the mega menu includes were changed from .inc to .txt as of WET v3.0.1, the SSI variant's references to them were in need of an update.
